### PR TITLE
fix: tab component warning message

### DIFF
--- a/src/components/Tabs/PiTabPanel.vue
+++ b/src/components/Tabs/PiTabPanel.vue
@@ -23,12 +23,12 @@ const props = defineProps({
     type: String,
     required: true
   },
-  prefixIcon: String,
+  prefix: String,
   label: {
     type: String,
     required: true
   },
-  affixIcon: String,
+  affix: String,
   badge: [String, Number],
   nopadding: Boolean
 })


### PR DESCRIPTION
修復 tab 的 prefix 會被設置的警告